### PR TITLE
ci: use ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,7 @@ jobs:
           name: elfs
           path: ./riscv-samples/bin/*.elf
   ci-check:
-    runs-on: ubuntu-latest
-    container: rust:1.88.0-bookworm 
+    runs-on: ubuntu-24.04  
     needs: build-samples
     steps:
       - uses: actions/checkout@v4
@@ -57,8 +56,7 @@ jobs:
       - name: Run tests
         run: cargo test --package "*" --locked -- --show-output
   cargo-fmt:
-    runs-on: ubuntu-latest
-    container: rust:1.88.0-bookworm 
+    runs-on: ubuntu-24.04 
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo fmt


### PR DESCRIPTION
Ubuntu 24.04 has Rust pre-installed. This allows us to skip downloading a Rust image from docker hub.