### PR TITLE
ci: use a special token for deploying docs

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: Push to GitHub pages
         uses: actions/deploy-pages@v4.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           artifact_name: "docs"


### PR DESCRIPTION
The default workflow permissions are too low. Raising the default permissions in the organization is a security concern. We will use a special token dedicated only for pushing to GitHub pages.