### PR TITLE
ci: make tests parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,29 +6,10 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
   RUST_BACKTRACE: "1"
-  RUSTVERSION: "1.88"
 
 jobs:
-  build-samples:
-    runs-on: ubuntu-latest
-    container: krinkin/rv64-toolchain:latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: build and capture
-        run: cd riscv-samples && make -j8 init-capture && make capture
-      - name: Upload traces
-        uses: actions/upload-artifact@v4
-        with:
-          name: traces
-          path: ./riscv-samples/traces/*.trace
-      - name: Upload elfs
-        uses: actions/upload-artifact@v4
-        with:
-          name: elfs
-          path: ./riscv-samples/bin/*.elf
   ci-check:
     runs-on: ubuntu-24.04  
-    needs: build-samples
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -40,22 +21,26 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ci-bookworm-${{ env.RUSTVERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ci-${{ runner.os }}-${{ env.RUSTVERSION }}-cargo-
-      - name: Build everything
-        run: cargo build --locked
-      - name: Load traces
-        uses: actions/download-artifact@v4
+          key: ci-check-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ci-check-cargo-
+      - run: cargo check --locked
+  unit-tests:
+    runs-on: ubuntu-24.04 
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        continue-on-error: false
         with:
-          name: traces
-          path: ./riscv-samples/traces
-      - name: Load elfs
-        uses: actions/download-artifact@v4
-        with:
-          name: elfs
-          path: ./riscv-samples/bin
-      - name: Run tests
-        run: cargo test --package "*" --locked -- --show-output
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ci-unit-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ci-unit-cargo-
+      - run: cargo test -q --lib --bins --locked
+      - run: cargo test --doc --locked
   cargo-fmt:
     runs-on: ubuntu-24.04 
     steps:
@@ -67,4 +52,15 @@ jobs:
     runs-on: ubuntu-24.04 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ci-doc-check-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ci-doc-check-cargo-
       - run: cargo doc --no-deps --document-private-items

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,55 @@
+name: Integration
+
+on: [push, pull_request]
+
+env:
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  build-samples:
+    runs-on: ubuntu-latest
+    container: krinkin/rv64-toolchain:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build and capture
+        run: cd riscv-samples && make -j8 init-capture && make capture
+      - name: Upload traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces
+          path: ./riscv-samples/traces/*.trace
+      - name: Upload elfs
+        uses: actions/upload-artifact@v4
+        with:
+          name: elfs
+          path: ./riscv-samples/bin/*.elf
+  integration-tests:
+    runs-on: ubuntu-24.04 
+    needs: build-samples
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ci-integration-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ci-integration-cargo-
+      - name: Load traces
+        uses: actions/download-artifact@v4
+        with:
+          name: traces
+          path: ./riscv-samples/traces
+      - name: Load elfs
+        uses: actions/download-artifact@v4
+        with:
+          name: elfs
+          path: ./riscv-samples/bin
+      - name: Run tests
+        run: cargo test --test vs_qemu_traces --locked -- --show-output


### PR DESCRIPTION
Make tests parallel and faster at the cost of a bit of more cache. This will also make it easier to see what kind of tests are failing.