### PR TITLE
Add instruction pretty printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "risc-v-sim"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc-v-sim"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/src/kernel/decoder.rs
+++ b/src/kernel/decoder.rs
@@ -167,33 +167,10 @@
 //! ));
 //! ```
 
-use serde::Serialize;
-use thiserror::Error;
-
 use crate::c_try;
 use crate::util::{bit, reg_x};
 
-use super::{Bit, InstrVal, Instruction, RegId, RegVal};
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Error, Serialize)]
-pub enum DecodeError {
-    #[error("Unknown instruction opcode: {0:#x}")]
-    UnknownOpcode(InstrVal),
-    #[error("Unknown op funct3 and funct7 values: {funct3:#x} and {funct7:#x}")]
-    UnknownOp { funct3: InstrVal, funct7: InstrVal },
-    #[error("Unknown imm-op funct3 value: {funct3:#x}")]
-    UnknownImmOp { funct3: InstrVal },
-    #[error("Unknown load op funct3 value: {funct3:#x}")]
-    UnknownLoadOp { funct3: InstrVal },
-    #[error("Unknown env-op funct3 and imm values: {funct3:#x} and {imm:#x}")]
-    UnknownEnvOp { funct3: InstrVal, imm: InstrVal },
-    #[error("Unknown store op funct3 value: {funct3:#x}")]
-    UnknownStoreOp { funct3: InstrVal },
-    #[error("Unknown bitwise shift type: {shtyp:#x}")]
-    UnknownImmOpShtyp { shtyp: InstrVal },
-    #[error("Unknown branch funct3 value: {funct3:#x}")]
-    UnknownBranch { funct3: InstrVal },
-}
+use super::{Bit, DecodeError, InstrVal, Instruction, RegId, RegVal};
 
 type Result<T> = std::result::Result<T, DecodeError>;
 

--- a/src/kernel/error.rs
+++ b/src/kernel/error.rs
@@ -1,0 +1,87 @@
+//! Errors returned by the kernel.
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::kernel::{InstrVal, InstructionInfo, RegVal};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]
+#[error(
+    "Failed to encode instruction {instruction_idx}: {instruction_code:#x} is not a valid instruction"
+)]
+pub struct InstructionDecodeError {
+    pub instruction_idx: usize,
+    pub instruction_code: InstrVal,
+    #[source]
+    pub error: DecodeError,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Error, Serialize)]
+pub enum KernelError {
+    #[error(
+        "Failed to execute instruction at {instruction_address:#x}: instruction: {instruction}: {instruction_error}"
+    )]
+    InstructionError {
+        instruction_address: RegVal,
+        instruction: InstructionInfo,
+        #[source]
+        instruction_error: InstructionError,
+    },
+    #[error("Failed to fetch instruction at {instruction_address:#x}: {memory_error}")]
+    FetchError {
+        instruction_address: RegVal,
+        #[source]
+        memory_error: MemoryError,
+    },
+    #[error(
+        "Failed to decode instruction at {instruction_address:#x} with code {instruction_code:#x}: {decode_error}"
+    )]
+    DecodeError {
+        instruction_address: RegVal,
+        instruction_code: InstrVal,
+        #[source]
+        decode_error: DecodeError,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Error, Serialize)]
+pub enum DecodeError {
+    #[error("Unknown instruction opcode: {0:#x}")]
+    UnknownOpcode(InstrVal),
+    #[error("Unknown op funct3 and funct7 values: {funct3:#x} and {funct7:#x}")]
+    UnknownOp { funct3: InstrVal, funct7: InstrVal },
+    #[error("Unknown imm-op funct3 value: {funct3:#x}")]
+    UnknownImmOp { funct3: InstrVal },
+    #[error("Unknown load op funct3 value: {funct3:#x}")]
+    UnknownLoadOp { funct3: InstrVal },
+    #[error("Unknown env-op funct3 and imm values: {funct3:#x} and {imm:#x}")]
+    UnknownEnvOp { funct3: InstrVal, imm: InstrVal },
+    #[error("Unknown store op funct3 value: {funct3:#x}")]
+    UnknownStoreOp { funct3: InstrVal },
+    #[error("Unknown bitwise shift type: {shtyp:#x}")]
+    UnknownImmOpShtyp { shtyp: InstrVal },
+    #[error("Unknown branch funct3 value: {funct3:#x}")]
+    UnknownBranch { funct3: InstrVal },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Error, Debug, Serialize)]
+pub enum InstructionError {
+    #[error("memory error: {0}")]
+    MemoryError(#[source] MemoryError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error, Serialize)]
+pub enum MemoryError {
+    #[error("Address {address:#x} is not mapped")]
+    AddressOutOfRange { address: RegVal },
+    #[error("Address {address:#x}: segment doesn't allow reads")]
+    AddressNotReadable { address: RegVal },
+    #[error("Address {address:#x}: segment doesn't allow writes")]
+    AddressNotWritable { address: RegVal },
+    #[error("Address {address:#x}: segment doesn't allow execution")]
+    AddressNotExecutable { address: RegVal },
+    #[error("Address {address:#x} is not {expected_alignment}-aligned")]
+    MisalignedAccess { address: RegVal, expected_alignment: usize },
+    #[error("Segment {off:#x}:{len:#x} overlaps existing: {found_off:#x}:{found_len:#x}")]
+    SegmentOverlap { found_off: RegVal, found_len: RegVal, off: RegVal, len: RegVal },
+}

--- a/src/kernel/instr_code_print.rs
+++ b/src/kernel/instr_code_print.rs
@@ -1,0 +1,170 @@
+//! Methods for pretty-printing instruction codes.
+
+use std::fmt;
+use std::io::{Cursor, Write};
+
+use crate::kernel::{INSTRVAL_BITS, Instruction, encode_instruction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PrettyBincode(pub Instruction);
+
+impl fmt::Display for PrettyBincode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let val = encode_instruction(self.0);
+        let mut bits = [0u8; INSTRVAL_BITS];
+        write!(Cursor::new(bits.as_mut_slice()), "{val:032b}").unwrap();
+        match self.0 {
+            Instruction::Jal(..) => write_j_type(&bits, f),
+            Instruction::Add(..)
+            | Instruction::Sub(..)
+            | Instruction::Xor(..)
+            | Instruction::Or(..)
+            | Instruction::And(..)
+            | Instruction::Sll(..)
+            | Instruction::Srl(..)
+            | Instruction::Sra(..)
+            | Instruction::Slt(..)
+            | Instruction::Sltu(..) => write_r_type(&bits, f),
+            Instruction::Lui(..) | Instruction::Auipc(..) => write_u_type(&bits, f),
+            Instruction::Addi(..)
+            | Instruction::Xori(..)
+            | Instruction::Ori(..)
+            | Instruction::Andi(..)
+            | Instruction::Slli(..)
+            | Instruction::Srli(..)
+            | Instruction::Srai(..)
+            | Instruction::Slti(..)
+            | Instruction::Sltiu(..)
+            | Instruction::Jalr(..)
+            | Instruction::Lb(..)
+            | Instruction::Lh(..)
+            | Instruction::Lw(..)
+            | Instruction::Lbu(..)
+            | Instruction::Lhu(..)
+            | Instruction::Ebreak => write_i_type(&bits, f),
+            Instruction::Sb(..) | Instruction::Sh(..) | Instruction::Sw(..) => {
+                write_s_type(&bits, f)
+            }
+            Instruction::Beq(..)
+            | Instruction::Bne(..)
+            | Instruction::Blt(..)
+            | Instruction::Bge(..)
+            | Instruction::Bltu(..)
+            | Instruction::Bgeu(..) => write_b_type(&bits, f),
+        }
+    }
+}
+
+/// Writes the bits with a layout like that of a J-type instruction
+pub fn write_j_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+        f,
+        "{} {} {}",
+        sub_slice(bits, 12, 32),
+        sub_slice(bits, 7, 12),
+        sub_slice(bits, 0, 7),
+    )
+}
+
+/// Writes the bits with a layout like that of a R-type instruction
+pub fn write_r_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+        f,
+        "{} {} {} {} {} {}",
+        sub_slice(bits, 25, 32),
+        sub_slice(bits, 20, 25),
+        sub_slice(bits, 15, 20),
+        sub_slice(bits, 12, 15),
+        sub_slice(bits, 7, 12),
+        sub_slice(bits, 0, 7),
+    )
+}
+
+/// Writes the bits with a layout like that of a U-type instruction
+pub fn write_u_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write_j_type(bits, f)
+}
+
+/// Writes the bits with a layout like that of a I-type instruction
+pub fn write_i_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+        f,
+        "{} {} {} {} {}",
+        sub_slice(bits, 20, 32),
+        sub_slice(bits, 15, 20),
+        sub_slice(bits, 12, 15),
+        sub_slice(bits, 7, 12),
+        sub_slice(bits, 0, 7),
+    )
+}
+
+/// Writes the bits with a layout like that of a S-type instruction
+pub fn write_s_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write_r_type(bits, f)
+}
+
+/// Writes the bits with a layout like that of a B-type instruction
+pub fn write_b_type(bits: &[u8; INSTRVAL_BITS], f: &mut fmt::Formatter) -> fmt::Result {
+    write_r_type(bits, f)
+}
+
+/// Helper for indexing bit digits, because they are backwards
+/// in printed notation.
+fn sub_slice(bits: &[u8; INSTRVAL_BITS], from: usize, to: usize) -> &str {
+    str::from_utf8(&bits[(INSTRVAL_BITS - to)..(INSTRVAL_BITS - from)]).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kernel::instr_code_print::PrettyBincode;
+    use crate::kernel::{Bit, Instruction, RegId};
+
+    #[test]
+    fn basic_formats() {
+        assert_eq!(
+            PrettyBincode(Instruction::Jal(RegId::ZERO, Bit::new(324 >> 1).unwrap(),)).to_string(),
+            "00010100010000000000 00000 1101111",
+        );
+
+        assert_eq!(
+            PrettyBincode(Instruction::Add(RegId::TP, RegId::T1, RegId::RA)).to_string(),
+            "0000000 00001 00110 000 00100 0110011",
+        );
+
+        assert_eq!(
+            PrettyBincode(Instruction::Lui(RegId::T1, Bit::new(4587).unwrap(),)).to_string(),
+            "00000001000111101011 00110 0110111",
+        );
+
+        assert_eq!(
+            PrettyBincode(Instruction::Addi(
+                RegId::A1,
+                RegId::A2,
+                Bit::new(20).unwrap(),
+            ))
+            .to_string(),
+            "000000010100 01100 000 01011 0010011",
+        );
+
+        assert_eq!(
+            PrettyBincode(Instruction::Sw(
+                RegId::T0,
+                RegId::T2,
+                Bit::new(123).unwrap(),
+            ))
+            .to_string(),
+            "0000011 00111 00101 010 11011 0100011",
+        );
+
+        assert_eq!(
+            PrettyBincode(Instruction::Beq(
+                RegId::T0,
+                RegId::T1,
+                Bit::new(0xC00).unwrap(),
+            ))
+            .to_string(),
+            "1000000 00110 00101 000 00001 1100011",
+        );
+    }
+}

--- a/src/kernel/instruction.rs
+++ b/src/kernel/instruction.rs
@@ -8,18 +8,10 @@ use std::{
 
 use log::debug;
 use serde::{Serialize, Serializer};
-use thiserror::Error;
 
 use crate::kernel::{REGVAL_SIZE_MASK, RegValSigned, instr_code_print::PrettyBincode};
 
-use super::{Memory, MemoryError, RegId, RegVal, Registers};
-
-/// Error returned by [`Instruction::execute`].
-#[derive(Clone, Copy, PartialEq, Eq, Error, Debug, Serialize)]
-pub enum InstructionError {
-    #[error("memory error: {0}")]
-    MemoryError(#[source] MemoryError),
-}
+use super::{InstructionError, Memory, RegId, RegVal, Registers};
 
 type Result<T> = std::result::Result<T, InstructionError>;
 

--- a/src/kernel/memory.rs
+++ b/src/kernel/memory.rs
@@ -1,26 +1,8 @@
 //! Memory subsystem of the kernel.
 
 use log::{debug, info, trace};
-use serde::Serialize;
-use thiserror::Error;
 
-use crate::kernel::{InstrVal, RegVal};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error, Serialize)]
-pub enum MemoryError {
-    #[error("Address {address:#x} is not mapped")]
-    AddressOutOfRange { address: RegVal },
-    #[error("Address {address:#x}: segment doesn't allow reads")]
-    AddressNotReadable { address: RegVal },
-    #[error("Address {address:#x}: segment doesn't allow writes")]
-    AddressNotWritable { address: RegVal },
-    #[error("Address {address:#x}: segment doesn't allow execution")]
-    AddressNotExecutable { address: RegVal },
-    #[error("Address {address:#x} is not {expected_alignment}-aligned")]
-    MisalignedAccess { address: RegVal, expected_alignment: usize },
-    #[error("Segment {off:#x}:{len:#x} overlaps existing: {found_off:#x}:{found_len:#x}")]
-    SegmentOverlap { found_off: RegVal, found_len: RegVal, off: RegVal, len: RegVal },
-}
+use crate::kernel::{InstrVal, MemoryError, RegVal};
 
 type Result<T> = std::result::Result<T, MemoryError>;
 

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -6,19 +6,19 @@
 //! 2. memory ([`memory::Memory`])
 
 pub mod decoder;
+pub mod error;
 pub mod instr_code_print;
 pub mod instruction;
 pub mod memory;
 pub mod registers;
 
 pub use decoder::*;
+pub use error::*;
 pub use instruction::*;
-use log::debug;
 pub use memory::*;
 pub use registers::*;
 
-use serde::Serialize;
-use thiserror::Error;
+use log::debug;
 
 #[derive(Debug)]
 pub struct Kernel {
@@ -170,17 +170,6 @@ impl Program {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]
-#[error(
-    "Failed to encode instruction {instruction_idx}: {instruction_code:#x} is not a valid instruction"
-)]
-pub struct InstructionDecodeError {
-    pub instruction_idx: usize,
-    pub instruction_code: InstrVal,
-    #[source]
-    pub error: DecodeError,
-}
-
 /// Result of a successful [`Kernel`] instruction step.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize)]
 pub struct KernelStep {
@@ -190,34 +179,6 @@ pub struct KernelStep {
     pub new_registers: Registers,
     /// The instruction that was executed.
     pub instruction: InstructionInfo,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Error, Serialize)]
-pub enum KernelError {
-    #[error(
-        "Failed to execute instruction at {instruction_address:#x}: instruction: {instruction}: {instruction_error}"
-    )]
-    InstructionError {
-        instruction_address: RegVal,
-        instruction: InstructionInfo,
-        #[source]
-        instruction_error: InstructionError,
-    },
-    #[error("Failed to fetch instruction at {instruction_address:#x}: {memory_error}")]
-    FetchError {
-        instruction_address: RegVal,
-        #[source]
-        memory_error: MemoryError,
-    },
-    #[error(
-        "Failed to decode instruction at {instruction_address:#x} with code {instruction_code:#x}: {decode_error}"
-    )]
-    DecodeError {
-        instruction_address: RegVal,
-        instruction_code: InstrVal,
-        #[source]
-        decode_error: DecodeError,
-    },
 }
 
 #[cfg(test)]

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -6,6 +6,7 @@
 //! 2. memory ([`memory::Memory`])
 
 pub mod decoder;
+pub mod instr_code_print;
 pub mod instruction;
 pub mod memory;
 pub mod registers;

--- a/src/kernel/registers.rs
+++ b/src/kernel/registers.rs
@@ -12,6 +12,7 @@ pub type InstrVal = u32;
 pub const REGVAL_SIZE_MASK: RegVal = 0x3F;
 /// Amount of registers available to the kernel.
 pub const GENERAL_REGISTER_COUNT: usize = 32;
+pub const INSTRVAL_BITS: usize = InstrVal::BITS as usize;
 
 /// A register container.
 ///

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -268,7 +268,7 @@ pub fn run_kernel(kernel: &mut Kernel, step_count: usize) -> RunResult {
         };
 
         steps.push(step);
-        if matches!(step.instruction, Instruction::Ebreak) {
+        if matches!(step.instruction.obj, Instruction::Ebreak) {
             break;
         }
     }


### PR DESCRIPTION
Risc-v-sim now includes pretty-printed instruction binary codes.
The codes are included both in traces and error detail JSONs.
Users may get the raw bincode by simply removing alls spaces.